### PR TITLE
Disable post-processing when an output plugin is used

### DIFF
--- a/bin/rpl_run.sh
+++ b/bin/rpl_run.sh
@@ -579,18 +579,20 @@ for name in $input_list; do
   fi
 done
 
-if [ -n "$csv_output" ] ; then
-  merge_output $OUTPUT_LIST
-  if [ "$GEN_STATS" = "1" ] ; then
-    db_output=$(echo $csv_output | sed "s/\.csv/.db/")
-    $ROCP_PYTHON_VERSION $BIN_DIR/tblextr.py $db_output $OUTPUT_LIST
-  else
-    $ROCP_PYTHON_VERSION $BIN_DIR/tblextr.py $csv_output $OUTPUT_LIST
-  fi
-  if [ "$?" -ne 0 ] ; then
-    echo "Profiling data corrupted: '$OUTPUT_LIST'" | tee "$ROCPROFILER_SESS/error"
-    RET=1
-  fi
+if [ $OUTPUT_PLUGIN = 1 ] ; then 
+	if [ -n "$csv_output" ] ; then
+	  merge_output $OUTPUT_LIST
+	  if [ "$GEN_STATS" = "1" ] ; then
+		db_output=$(echo $csv_output | sed "s/\.csv/.db/")
+		$ROCP_PYTHON_VERSION $BIN_DIR/tblextr.py $db_output $OUTPUT_LIST
+	  else
+		$ROCP_PYTHON_VERSION $BIN_DIR/tblextr.py $csv_output $OUTPUT_LIST
+	  fi
+	  if [ "$?" -ne 0 ] ; then
+		echo "Profiling data corrupted: '$OUTPUT_LIST'" | tee "$ROCPROFILER_SESS/error"
+		RET=1
+	  fi
+	fi
 fi
 
 if [ "$DATA_PATH" = "$TMP_DIR" ] ; then

--- a/bin/rpl_run.sh
+++ b/bin/rpl_run.sh
@@ -579,7 +579,7 @@ for name in $input_list; do
   fi
 done
 
-if [ $OUTPUT_PLUGIN = 1 ] ; then 
+if [ $OUTPUT_PLUGIN = 0 ] ; then 
 	if [ -n "$csv_output" ] ; then
 	  merge_output $OUTPUT_LIST
 	  if [ "$GEN_STATS" = "1" ] ; then


### PR DESCRIPTION
This PR allows disabling post-processing when using the --output-plugin option.
When an output plugin is used, the output format changes, and the post-processing scripts are not adapted anymore.
Also, before this PR, post-processing scripts created files with nonunique names (such as results.sysinfo.txt) leading to concurrency issues when using rocprof in an MPI program. This PR also is a workaround to this issue when using a plugin.  